### PR TITLE
chore: minor fix brew warnings

### DIFF
--- a/Formula/nsolid-gallium.rb
+++ b/Formula/nsolid-gallium.rb
@@ -1,4 +1,4 @@
-class Nsolid < Formula
+class NsolidGallium < Formula
   desc "N|Solid Runtime Gallium"
   homepage "https://nodesource.com/products/nsolid"
   url "https://s3-us-west-2.amazonaws.com/nodesource-public-downloads/4.9.3/artifacts/bundles/nsolid-bundle-v4.9.3-darwin-x64/nsolid-v4.9.3-gallium-darwin-x64.tar.gz"

--- a/Formula/nsolid.rb
+++ b/Formula/nsolid.rb
@@ -7,7 +7,7 @@ class Nsolid < Formula
 
   conflicts_with "node", :because => "N|Solid is a replacement for NodeJS"
   conflicts_with "nsolid-gallium", :because => "N|Solid Hydrogen is a replacement for N|Solid Gallium"
-  depends_on :macos => :yosemite
+  depends_on :macos => :el_capitan
 
   option "without-node", "Won't symlink node, npm, and npx in /usr/local/bin/ to the N|Solid versions"
 


### PR DESCRIPTION
yosemite is not longer supported by brew.
https://github.com/Homebrew/brew/releases/tag/3.5.0
https://github.com/Homebrew/brew/pull/13378

that;s why we get this warnigng
```
Warning: Calling depends_on :macos => :yosemite is deprecated! There is no replacement.
Please report this issue to the nodesource/nsolid tap (not Homebrew/brew or Homebrew/homebrew-core):
  /usr/local/Homebrew/Library/Taps/nodesource/homebrew-nsolid/Formula/nsolid.rb:10
```