### PR TITLE
Support Nsolid krypton

### DIFF
--- a/Formula/nsolid-iron.rb
+++ b/Formula/nsolid-iron.rb
@@ -8,11 +8,15 @@ class NsolidIron < Formula
   elsif Hardware::CPU.arm?
     url "https://s3-us-west-2.amazonaws.com/nodesource-public-downloads/20.19.5-ns6.0.2/artifacts/binaries/nsolid-v6.0.2-iron-darwin-arm64.tar.gz"
     sha256 "00bb3d4dd522e910c1e3af8a2d60ec990c5fdfd3820f372169884c1ec50e1ce9"
+  elsif Hardware::CPU.arm?
+    url "https://s3-us-west-2.amazonaws.com/nodesource-public-downloads/20.19.5-ns6.0.2/artifacts/binaries/nsolid-v6.0.2-iron-darwin-arm64.tar.gz"
+    sha256 "00bb3d4dd522e910c1e3af8a2d60ec990c5fdfd3820f372169884c1ec50e1ce9"
   end
 
   conflicts_with "node", because: "N|Solid replaces NodeJS"
   conflicts_with "nsolid-hydrogen", because: "N|Solid Iron replaces N|Solid Hydrogen"
-  conflicts_with "nsolid-jod", because: "N|Solid Iron replaces N|Solid Jod"
+  conflicts_with "nsolid-jod", because: "N|Solid Jod replaces N|Solid Iron"
+  conflicts_with "nsolid-krypton", because: "N|Solid Krypton replaces N|Solid Iron"
   depends_on macos: :el_capitan
 
   option "without-node", "Avoids symlinking node, npm, and npx in /usr/local/bin/ to the N|Solid versions"

--- a/Formula/nsolid-jod.rb
+++ b/Formula/nsolid-jod.rb
@@ -13,6 +13,7 @@ class NsolidJod < Formula
   conflicts_with "node", because: "N|Solid replaces NodeJS"
   conflicts_with "nsolid-hydrogen", because: "N|Solid Jod replaces N|Solid Hydrogen"
   conflicts_with "nsolid-iron", because: "N|Solid Jod replaces N|Solid Iron"
+  conflicts_with "nsolid-krypton", because: "N|Solid Jod replaces N|Solid Krypton"
   depends_on macos: :el_capitan
 
   option "without-node", "Avoids symlinking node, npm, and npx in /usr/local/bin/ to the N|Solid versions"

--- a/Formula/nsolid-krypton.rb
+++ b/Formula/nsolid-krypton.rb
@@ -1,0 +1,36 @@
+class NsolidKrypton < Formula
+  desc "N|Solid Runtime Krypton"
+  homepage "https://nodesource.com/products/nsolid"
+
+  if Hardware::CPU.intel?
+    url "https://s3-us-west-2.amazonaws.com/nodesource-public-downloads/24.11.0-ns6.0.2/artifacts/binaries/nsolid-v6.0.2-krypton-darwin-x64.tar.gz"
+    sha256 ""
+  elsif Hardware::CPU.arm?
+    url "https://s3-us-west-2.amazonaws.com/nodesource-public-downloads/24.11.0-ns6.0.2/artifacts/binaries/nsolid-v6.0.2-krypton-darwin-arm64.tar.gz"
+    sha256 ""
+  end
+
+  conflicts_with "node", because: "N|Solid replaces NodeJS"
+  conflicts_with "nsolid-hydrogen", because: "N|Solid Krypton replaces N|Solid Hydrogen"
+  conflicts_with "nsolid-iron", because: "N|Solid Krypton replaces N|Solid Iron"
+  conflicts_with "nsolid-jod", because: "N|Solid Krypton replaces N|Solid Jod"
+  depends_on macos: :el_capitan
+
+  option "without-node", "Avoids symlinking node, npm, and npx in /usr/local/bin/ to the N|Solid versions"
+
+  def install
+    lib.install Dir["lib/*"]
+    share.install Dir["share/*"]
+    include.install Dir["include/*"]
+    if build.without? "node"
+      bin.install Dir["bin/nsolid"], Dir["bin/nsolid-cli"]
+    else
+      bin.install Dir["bin/*"]
+    end
+  end
+
+  test do
+    system "nsolid", "-vv"
+    system "nsolid-cli", "-v"
+  end
+end

--- a/update.py
+++ b/update.py
@@ -60,7 +60,7 @@ if __name__ == "__main__":
         exit(1)
 
     node_version, ns_version = match.groups()
-    codenames = {18: "hydrogen", 20: "iron", 22: "jod"}
+    codenames = {18: "hydrogen", 20: "iron", 22: "jod", 24: "krypton"}
     codename = codenames.get(int(node_version))
     if not codename:
         print("Unsupported Node version for determining codename.")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * N|Solid Krypton now available for macOS (Intel and ARM architectures)
  * Extended support for Node.js version 24
  * Updated compatibility management across N|Solid product versions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->