### PR TITLE
fix: drop el_capitan dep, point alias to krypton

### DIFF
--- a/Aliases/nsolid
+++ b/Aliases/nsolid
@@ -1,1 +1,1 @@
-../Formula/nsolid-iron.rb
+../Formula/nsolid-krypton.rb

--- a/Formula/nsolid-hydrogen.rb
+++ b/Formula/nsolid-hydrogen.rb
@@ -13,7 +13,6 @@ class NsolidHydrogen < Formula
   conflicts_with "node", because: "N|Solid replaces NodeJS"
   conflicts_with "nsolid-iron", because: "N|Solid Hydrogen replaces N|Solid Iron"
   conflicts_with "nsolid-jod", because: "N|Solid Hydrogen replaces N|Solid Jod"
-  depends_on macos: :el_capitan
 
   option "without-node", "Avoids symlinking node, npm, and npx in /usr/local/bin/ to the N|Solid versions"
 

--- a/Formula/nsolid-iron.rb
+++ b/Formula/nsolid-iron.rb
@@ -17,7 +17,6 @@ class NsolidIron < Formula
   conflicts_with "nsolid-hydrogen", because: "N|Solid Iron replaces N|Solid Hydrogen"
   conflicts_with "nsolid-jod", because: "N|Solid Jod replaces N|Solid Iron"
   conflicts_with "nsolid-krypton", because: "N|Solid Krypton replaces N|Solid Iron"
-  depends_on macos: :el_capitan
 
   option "without-node", "Avoids symlinking node, npm, and npx in /usr/local/bin/ to the N|Solid versions"
 

--- a/Formula/nsolid-jod.rb
+++ b/Formula/nsolid-jod.rb
@@ -14,7 +14,6 @@ class NsolidJod < Formula
   conflicts_with "nsolid-hydrogen", because: "N|Solid Jod replaces N|Solid Hydrogen"
   conflicts_with "nsolid-iron", because: "N|Solid Jod replaces N|Solid Iron"
   conflicts_with "nsolid-krypton", because: "N|Solid Jod replaces N|Solid Krypton"
-  depends_on macos: :el_capitan
 
   option "without-node", "Avoids symlinking node, npm, and npx in /usr/local/bin/ to the N|Solid versions"
 

--- a/Formula/nsolid-krypton.rb
+++ b/Formula/nsolid-krypton.rb
@@ -14,7 +14,6 @@ class NsolidKrypton < Formula
   conflicts_with "nsolid-hydrogen", because: "N|Solid Krypton replaces N|Solid Hydrogen"
   conflicts_with "nsolid-iron", because: "N|Solid Krypton replaces N|Solid Iron"
   conflicts_with "nsolid-jod", because: "N|Solid Krypton replaces N|Solid Jod"
-  depends_on macos: :el_capitan
 
   option "without-node", "Avoids symlinking node, npm, and npx in /usr/local/bin/ to the N|Solid versions"
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default nsolid package alias to reference the latest available version
  * Removed legacy macOS minimum version requirements from multiple package variants, broadening compatibility across a wider range of macOS environments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->